### PR TITLE
Potential fix for code scanning alert no. 3: Log entries created from user input

### DIFF
--- a/MonkeyScheduler.WorkerService/Controllers/TaskReceiverController.cs
+++ b/MonkeyScheduler.WorkerService/Controllers/TaskReceiverController.cs
@@ -34,14 +34,14 @@ namespace MonkeyScheduler.WorkerService.Controllers
 
             try
             {
-                _logger.LogInformation("收到任务执行请求: {TaskName}", task.Name);
+                _logger.LogInformation("收到任务执行请求: {TaskName}", task.Name?.Replace("\r", "").Replace("\n", ""));
                 
                 await _executor.ExecuteAsync(task, async result =>
                 {
                     await _statusReporter.ReportStatusAsync(result);
                 });
                 
-                _logger.LogInformation("任务执行完成: {TaskName}", task.Name);
+                _logger.LogInformation("任务执行完成: {TaskName}", task.Name?.Replace("\r", "").Replace("\n", ""));
                 return Ok();
             }
             catch (Exception ex)


### PR DESCRIPTION
Potential fix for [https://github.com/MiaoShuYo/MonkeyScheduler/security/code-scanning/3](https://github.com/MiaoShuYo/MonkeyScheduler/security/code-scanning/3)

To fix the problem, we should sanitize the user input before logging it. Specifically, for plain text logs, we should remove or replace newline characters and other control characters from `task.Name` before passing it to the logger. The best way is to use `String.Replace` to remove `\r` and `\n` from `task.Name` before logging. This should be done in all places where `task.Name` is logged, including line 44 and line 37 (which also logs `task.Name`).  
No new methods are needed, but we should ensure the replacement is performed inline where the logging occurs.  
No new imports are required, as `String.Replace` is part of the standard library.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
